### PR TITLE
fix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ func main() {
 	}
 
 	// client
-	cli := client.NewClient("127.0.0.1:8000")
+	cli := client.NewClient("http://127.0.0.1:8000")
 	// adding job to delay queue, if job is exist will be failed
 	if err = cli.AddJob(j); err != nil {
 		panic(err)

--- a/example/main.go
+++ b/example/main.go
@@ -17,7 +17,7 @@ func main() {
 	}
 
 	// client
-	cli := client.NewClient("127.0.0.1:8000")
+	cli := client.NewClient("http://127.0.0.1:8000")
 	// adding job to delay queue, if job is exist will be failed
 	if err = cli.AddJob(j); err != nil {
 		panic(err)


### PR DESCRIPTION
go 1.16

when I run this code I get this output :
panic: parse "127.0.0.1:8000/topic/topic1/job": first path segment in URL cannot contain colon